### PR TITLE
Add removing adventurers

### DIFF
--- a/src/components/lists/CharaList/CharaList_CharaUpgradeButtons.jsx
+++ b/src/components/lists/CharaList/CharaList_CharaUpgradeButtons.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 
 import { useSelector, useDispatch } from 'react-redux';
 import { updateJsonDataListField, addJsonDataListObject,
-  replaceJsonDataListObject, addToObjectListObjectField } from '../../../actions/JsonDataActions';
+  replaceJsonDataListObject, removeJsonDataListObject, addToObjectListObjectField } from '../../../actions/JsonDataActions';
 
 import Button from '@mui/material/Button';
 import ButtonGroup from '@mui/material/ButtonGroup';
@@ -21,7 +21,7 @@ const MAX_AUGMENT_COUNT = 100;
 function CharaList_CharaUpgradeButtons({adventurerId, adventurerMeta}) {
 
   const dispatch = useDispatch();
-  const { addAdventurerStory, maxAdventurer } = useDragaliaActions();
+  const { addAdventurerStory, removeAdventurerStory, maxAdventurer } = useDragaliaActions();
 
   const adventurerObject = useSelector(state => state.jsonData.data.chara_list
     .find(adventurerObject => adventurerObject["chara_id"] === adventurerId));

--- a/src/components/lists/CharaList/CharaList_CharaUpgradeButtons.jsx
+++ b/src/components/lists/CharaList/CharaList_CharaUpgradeButtons.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 
-import { useSelector, useDispatch } from 'react-redux'; 
-import { updateJsonDataListField, addJsonDataListObject, 
+import { useSelector, useDispatch } from 'react-redux';
+import { updateJsonDataListField, addJsonDataListObject,
   replaceJsonDataListObject, addToObjectListObjectField } from '../../../actions/JsonDataActions';
 
 import Button from '@mui/material/Button';
@@ -18,26 +18,38 @@ import notteWtfIcon from '../../../assets/icons/nottewtf.png';
 
 const MAX_AUGMENT_COUNT = 100;
 
-function CharaList_CharaUpgradeButtons({adventurerId, adventurerMeta}) { 
-  
+function CharaList_CharaUpgradeButtons({adventurerId, adventurerMeta}) {
+
   const dispatch = useDispatch();
   const { addAdventurerStory, maxAdventurer } = useDragaliaActions();
 
   const adventurerObject = useSelector(state => state.jsonData.data.chara_list
     .find(adventurerObject => adventurerObject["chara_id"] === adventurerId));
-  
+
   const isOwned = adventurerObject ? true : false;
-    
+
   const onGet = () => {
     const newAdventurerObject = DragaliaUtils.getNewAdventurer(adventurerMeta);
     dispatch(addJsonDataListObject("chara_list", newAdventurerObject));
     addAdventurerStory(adventurerId, true);
     dispatch(addToObjectListObjectField(
-      "fort_bonus_list", "chara_bonus_by_album", "elemental_type", 
+      "fort_bonus_list", "chara_bonus_by_album", "elemental_type",
       adventurerMeta.ElementalTypeId, "hp", 0.1));
     dispatch(addToObjectListObjectField(
-      "fort_bonus_list", "chara_bonus_by_album", "elemental_type", 
+      "fort_bonus_list", "chara_bonus_by_album", "elemental_type",
       adventurerMeta.ElementalTypeId, "attack", 0.1));
+  }
+
+  const onRemove = () => {
+    dispatch(removeJsonDataListObject("chara_list", "chara_id", adventurerId));
+    removeAdventurerStory(adventurerId, true);
+
+    dispatch(addToObjectListObjectField(
+      "fort_bonus_list", "chara_bonus_by_album", "elemental_type",
+      adventurerMeta.ElementalTypeId, "hp", -0.1));
+    dispatch(addToObjectListObjectField(
+      "fort_bonus_list", "chara_bonus_by_album", "elemental_type",
+      adventurerMeta.ElementalTypeId, "attack", -0.1));
   }
 
   const onMax = () => {
@@ -57,14 +69,14 @@ function CharaList_CharaUpgradeButtons({adventurerId, adventurerMeta}) {
         console.error(`Invalid stat type: ${statType}`);
         return;
     }
-    dispatch(updateJsonDataListField("chara_list", 
+    dispatch(updateJsonDataListField("chara_list",
       "chara_id", adventurerId, field, MAX_AUGMENT_COUNT));
   }
-  
+
   const commonProps = {
     variant: 'contained',
     style: { backgroundColor: '#7a62f0' },
-    sx: { 
+    sx: {
       textTransform: 'none',
       color: 'white',
       '&.Mui-disabled': {
@@ -76,9 +88,9 @@ function CharaList_CharaUpgradeButtons({adventurerId, adventurerMeta}) {
 
   return (
     <ButtonGroup style={{ gap: '10px', display: 'flex', flexWrap: 'wrap', justifyContent: 'center' }}>
-      <Button 
-        key="get" 
-        onClick={() => onGet() } 
+      <Button
+        key="get"
+        onClick={() => onGet() }
         disabled={
           isOwned
         }
@@ -86,9 +98,19 @@ function CharaList_CharaUpgradeButtons({adventurerId, adventurerMeta}) {
       >
         Get
       </Button>
-      <Button 
-        key="max_hp_augments" 
-        onClick={() => onMaxAugments(StatType.HP) } 
+      <Button
+        key="Remove"
+        onClick={() => onRemove() }
+        disabled={
+          !isOwned
+        }
+        {...commonProps}
+      >
+        Remove
+      </Button>
+      <Button
+        key="max_hp_augments"
+        onClick={() => onMaxAugments(StatType.HP) }
         {...commonProps}
         disabled={
           !isOwned ||
@@ -97,9 +119,9 @@ function CharaList_CharaUpgradeButtons({adventurerId, adventurerMeta}) {
       >
         Max HP Augments
       </Button>
-      <Button 
-        key="max_str_augments" 
-        onClick={() => onMaxAugments(StatType.STRENGTH) } 
+      <Button
+        key="max_str_augments"
+        onClick={() => onMaxAugments(StatType.STRENGTH) }
         {...commonProps}
         disabled={
           !isOwned ||
@@ -108,19 +130,19 @@ function CharaList_CharaUpgradeButtons({adventurerId, adventurerMeta}) {
       >
         Max Strength Augments
       </Button>
-      <Button 
-        key="max" 
-        onClick={() => onMax() } 
+      <Button
+        key="max"
+        onClick={() => onMax() }
         {...commonProps}
         disabled={
-          DragaliaUtils.isAdventurerMaxed(adventurerObject, adventurerMeta) 
+          DragaliaUtils.isAdventurerMaxed(adventurerObject, adventurerMeta)
         }
       >
         Max
       </Button>
     </ButtonGroup>
   );
-  
+
 
 }
 

--- a/src/components/lists/CharaList/CharaList_CharaUpgradeButtons.jsx
+++ b/src/components/lists/CharaList/CharaList_CharaUpgradeButtons.jsx
@@ -42,7 +42,7 @@ function CharaList_CharaUpgradeButtons({adventurerId, adventurerMeta}) {
 
   const onRemove = () => {
     dispatch(removeJsonDataListObject("chara_list", "chara_id", adventurerId));
-    removeAdventurerStory(adventurerId, true);
+    removeAdventurerStory(adventurerId);
 
     dispatch(addToObjectListObjectField(
       "fort_bonus_list", "chara_bonus_by_album", "elemental_type",

--- a/src/components/lists/CharaList/CharaList_CharaUpgradeButtons.jsx
+++ b/src/components/lists/CharaList/CharaList_CharaUpgradeButtons.jsx
@@ -41,6 +41,13 @@ function CharaList_CharaUpgradeButtons({adventurerId, adventurerMeta}) {
   }
 
   const onRemove = () => {
+    const MEGA_MAN = 10750102;
+    const PRINCE = 10140101;
+
+    if (adventurerId === MEGA_MAN || adventurerId === PRINCE) {
+      return;
+    }
+
     dispatch(removeJsonDataListObject("chara_list", "chara_id", adventurerId));
     removeAdventurerStory(adventurerId);
 
@@ -102,7 +109,7 @@ function CharaList_CharaUpgradeButtons({adventurerId, adventurerMeta}) {
         key="Remove"
         onClick={() => onRemove() }
         disabled={
-          !isOwned
+          !isOwned || [10750102, 10140101].includes(adventurerId)
         }
         {...commonProps}
       >

--- a/src/reducers/JsonDataReducer.js
+++ b/src/reducers/JsonDataReducer.js
@@ -1,5 +1,5 @@
-import { 
-  UPDATE_JSON_DATA, UPDATE_OBJECT_FIELD, UPDATE_LIST_FIELD, 
+import {
+  UPDATE_JSON_DATA, UPDATE_OBJECT_FIELD, UPDATE_LIST_FIELD,
   ADD_LIST_OBJECT, REPLACE_LIST_OBJECT, SET_LIST,
   ADD_EDITOR_INFOS, REMOVE_LIST_OBJECT, RESET_LIST_OBJECT_LIST_FIELD,
   ADD_TO_OBJECT_LIST_OBJECT_FIELD, SET_OBJECT_OBJECT,
@@ -153,7 +153,7 @@ function jsonDataReducer(state = initialState, action) {
         if (!found) {
           console.warn(`Item with ${idFieldName}=${id} not found in ${listName}.`);
         }
-        break; 
+        break;
       }
       case SET_OBJECT_OBJECT: {
         const { objectName, objectName2, object } = action.payload;
@@ -176,5 +176,5 @@ function jsonDataReducer(state = initialState, action) {
     }
   });
 }
-  
+
 export default jsonDataReducer;

--- a/src/util/DragaliaActionsUtils.js
+++ b/src/util/DragaliaActionsUtils.js
@@ -62,7 +62,7 @@ const useDragaliaActions = () => {
         }
     };
 
-    const removeAdventurerStory = (adventurerId, removeAll) => {
+    const removeAdventurerStory = (adventurerId) => {
 
         const MEGA_MAN = 10750102;
         const PRINCE = 10140101;
@@ -71,14 +71,13 @@ const useDragaliaActions = () => {
             return;
         }
 
-        const count = removeAll ? 5 : 1;
         const stories = maps.charaStoryMap[adventurerId];
         if (stories === undefined) {
             console.error(`No stories found for adventurer ID: ${adventurerId}`);
             return;
         }
         const storyIds = JsonUtils.getSetFromList(unitStoryList, "unit_story_id");
-        for (let i = 0; i < count; i++) {
+        for (let i = 0; i < stories.length; i++) {
             const storyId = stories[i];
             if (storyId === undefined) {
                 console.error(`No story found for adventurer ID: ${adventurerId} at index: ${i}`);

--- a/src/util/DragaliaActionsUtils.js
+++ b/src/util/DragaliaActionsUtils.js
@@ -76,16 +76,14 @@ const useDragaliaActions = () => {
             console.error(`No stories found for adventurer ID: ${adventurerId}`);
             return;
         }
+
         const storyIds = JsonUtils.getSetFromList(unitStoryList, "unit_story_id");
-        for (let i = 0; i < stories.length; i++) {
-            const storyId = stories[i];
-            if (storyId === undefined) {
-                console.error(`No story found for adventurer ID: ${adventurerId} at index: ${i}`);
-                return;
-            }
+
+        for (const storyId of Object.values(stories)) {
             if (!storyIds.has(storyId)) {
                 continue;
             }
+
             dispatch(removeJsonDataListObject("unit_story_list", "unit_story_id", storyId));
         }
     };

--- a/src/util/DragaliaActionsUtils.js
+++ b/src/util/DragaliaActionsUtils.js
@@ -100,14 +100,6 @@ const useDragaliaActions = () => {
         dispatch(addJsonDataListObject("unit_story_list", story));
     }
 
-    const removeDragonStory = (dragonMeta, id) => {
-        const storyId = +`${dragonMeta.BaseId}01${id}`
-        if (!JsonUtils.listHasValue(unitStoryList, "unit_story_id", storyId)) {
-            return;
-        }
-        dispatch(removeJsonDataListObject("unit_story_list", "unit_story_id", storyId));
-    }
-
     // given a dragon object to be maxed, update encyclopedia bonus and entry
     const handleDragonEncyclopedia = (dragonObject) => {
         const id = dragonObject.dragon_id;
@@ -408,7 +400,6 @@ const useDragaliaActions = () => {
         addAdventurerStory,
         removeAdventurerStory,
         addDragonStory,
-        removeDragonStory,
         handleDragonEncyclopedia,
         maxAdventurer,
         addDragon,

--- a/src/util/DragaliaActionsUtils.js
+++ b/src/util/DragaliaActionsUtils.js
@@ -2,7 +2,7 @@ import { useDispatch } from 'react-redux';
 import { useContext } from 'react';
 import { useSelector } from 'react-redux';
 import { MappingContext } from '../components/SaveEditor';
-import { addJsonDataListObject, replaceJsonDataListObject, addToObjectListObjectField,
+import { addJsonDataListObject, removeJsonDataListObject, replaceJsonDataListObject, addToObjectListObjectField,
     updateJsonDataObjectField
 } from '../actions/JsonDataActions';
 


### PR DESCRIPTION
Hi sockperson,

Thanks for creating this great web-based save file editor. This pull request adds a "Remove" button after the "Get" button under the Adventurers list, which:

* Removes the selected adventurer from `chara_list`
* Undoes their fort bonus (applies -0.1 to hp and attack for their element)
* Removes all of their character stories

Below are a before, after, and diff of an example removal of 2 adventurers from a save file.

📎 [before.json](https://github.com/user-attachments/files/18134249/before.json)
📎 [after.json](https://github.com/user-attachments/files/18134250/after.json)
📎 [diff.txt](https://github.com/user-attachments/files/18134252/diff.txt)

Cheers!